### PR TITLE
If localhost use fy.re

### DIFF
--- a/src/auth-api.js
+++ b/src/auth-api.js
@@ -245,6 +245,11 @@ function networkFromToken (token) {
 
 function serverUrlFromToken(token) {
     var network = networkFromToken(token);
-    var serverUrl = document.location.protocol + '//admin.' + network;
+    var serverUrl = document.location.protocol + '//admin.';
+    // when we are serving locally, admin.livefyre.com -> admin.fy.re
+    if (document.location.hostname == 'localhost') {
+        network = 'fy.re';
+    }
+    serverUrl += network;
     return serverUrl;
 }


### PR DESCRIPTION
I am very meh about this. Really there should be a better way of sharing the 'serverUrl' that is on the delegate instance. However, currently auth ensures that the serverUrl is in a private closure.
